### PR TITLE
docs: add MedHELM taxonomy and leaderboard notes

### DIFF
--- a/docs/leaderboards/leaderboards.markdown
+++ b/docs/leaderboards/leaderboards.markdown
@@ -24,6 +24,7 @@ The following pages discuss the leaderboards already available:
 Other leaderboards of note from other organizations include the following:
 
 * [AIR-Bench 2024](https://crfm.stanford.edu/helm/air-bench/latest/){:target="airbench"} from the [Stanford University HELM project](https://crfm.stanford.edu/helm/){:target="helm"}: A safety benchmark aligned with emerging government regulations and company policies, following the regulation-based safety categories grounded in the HELM AI Risks study, AIR 2024.
+* [MedHELM](https://crfm.stanford.edu/helm/medhelm/latest/){:target="medhelm"} (Holistic Evaluation of Large Language Models for Medical Tasks) from Stanford CRFM HELM reports leaderboard results for medical tasks. See the [paper](https://www.nature.com/articles/s41591-025-04151-2){:target="medhelm_paper"} and [documentation](https://crfm-helm.readthedocs.io/en/latest/medhelm/){:target="medhelm_docs"}. Results should be presented as task-level evaluation evidence, not as clinical readiness, clinical safety, regulatory clearance, or healthcare deployment endorsement.
 * [Galileo Agent Leaderboard v2](https://huggingface.co/spaces/galileo-ai/agent-leaderboard){:target="galileo-lb"} from [Galileo AI](https://galileo.ai){:target="galileo"} evaluates the performance of LLM agents across business domains. Their [data set](https://huggingface.co/datasets/galileo-ai/agent-leaderboard-v2){:target="galileo-data"} could be useful for custom domain-specific evaluation. 
 
 ## Plans for Leaderboards and Other Tools

--- a/docs/taxonomy/taxonomy.markdown
+++ b/docs/taxonomy/taxonomy.markdown
@@ -27,6 +27,7 @@ However, some sections of a potential global taxonomy have been extensively expl
 * MIT [AI Risk Repository](https://airisk.mit.edu/){:target="mit-ai"}
 * NIST [Risk Management Framework](https://airc.nist.gov/AI_RMF_Knowledge_Base/AI_RMF/Foundational_Information/3-sec-characteristics){:target="nist-rmf"}
 * Stanford [CRFM HELM](https://crfm.stanford.edu/helm/){:target="helm"}
+* Stanford [MedHELM](https://crfm.stanford.edu/helm/medhelm/latest/){:target="medhelm"} extends CRFM HELM for medical tasks. Its documentation describes a taxonomy with 5 categories, 22 subcategories, and 121 clinical tasks, going beyond exam-based medical question answering to include clinical task framing and healthcare scenarios such as diagnostic decision-making and patient communication. It is evaluation context, not a claim of clinical readiness.
 
 ## An AI Alliance Taxonomy - A First Pass
 


### PR DESCRIPTION
## Summary
- Adds MedHELM as a healthcare-focused taxonomy source.
- Adds MedHELM to external leaderboards with links to the leaderboard, paper, and documentation.
- Adds claim-boundary wording so benchmark results are not presented as clinical readiness, clinical safety, regulatory clearance, or deployment endorsement.

## Validation
- `git diff --check origin/main...HEAD`
- Verified source URLs: MedHELM leaderboard, Nature Medicine paper, and MedHELM documentation.
- Jekyll build not run locally because required gems are not installed (`bundle check` reports missing dependencies).

References #50
